### PR TITLE
Testing updates

### DIFF
--- a/lib/unique_identifier.rb
+++ b/lib/unique_identifier.rb
@@ -11,6 +11,7 @@ module UniqueIdentifier
       const_set('BLOCK', block)
       const_set('FIELD', field)
       before_validation :generate_unique_id, on: :create
+      include InstanceMethods
     end
 
   end
@@ -32,7 +33,6 @@ module UniqueIdentifier
   module Glue
     def self.included(base)
       base.extend(ClassMethods)
-      base.send :include, InstanceMethods
     end
   end
 

--- a/lib/unique_identifier/matchers.rb
+++ b/lib/unique_identifier/matchers.rb
@@ -1,0 +1,26 @@
+require 'unique_identifier/matchers/have_unique_id_matcher'
+
+module UniqueIdentifier
+  module Shoulda
+    #
+    # NOTE: borrowing heavily here from Paperclip,
+    # e.g. HaveAttachedFileMatcher
+    #
+    # In spec_helper.rb, you'll need to require the matchers:
+    #
+    #   require "unique_identifier/matchers"
+    #
+    # And _include_ the module:
+    #
+    #   RSpec.configure do |config|
+    #     config.include UniqueIdentifier::Shoulda::Matchers
+    #   end
+    #
+    # Example:
+    #   describe Order do
+    #     it { should have_unique_id(:number) }
+    #   end
+    module Matchers
+    end
+  end
+end

--- a/lib/unique_identifier/matchers/have_unique_id_matcher.rb
+++ b/lib/unique_identifier/matchers/have_unique_id_matcher.rb
@@ -1,0 +1,62 @@
+module UniqueIdentifier
+  module Shoulda
+    module Matchers
+      # Example:
+      #   describe Order do
+      #     it { should have_unique_id(:number) }
+      #   end
+      def have_unique_id name
+        HaveUniqueIdMatcher.new(name)
+      end
+
+      class HaveUniqueIdMatcher
+        def initialize column_name
+          @column_name = column_name
+          @failure_messages = []
+        end
+
+        def matches? subject
+          @subject = subject
+          @subject = @subject.class unless Class === @subject
+          responds? && has_column? && block_returns_unique?
+        end
+
+        def failure_message
+          base_msg = "Should call `unique_id` for column `#{@column_name}`"
+          @failure_messages.unshift(base_msg)
+          @failure_messages.join("\n")
+        end
+
+        def failure_message_when_negated
+          "Should not call `unique_id` for column `#{@column_name}`"
+        end
+        alias negative_failure_message failure_message_when_negated
+
+        def description
+          "have `unique_id` declaration for #{@column_name}"
+        end
+
+        protected
+
+        def responds?
+          @subject.instance_methods.include?(:generate_unique_id)
+        end
+
+        def has_column?
+          @subject.column_names.include?("#{@column_name}")
+        end
+
+        def block_returns_unique?
+          results = Array.new(3) do
+            @subject.const_get('UNIQUE_IDENTIFIER_BLOCK').call
+          end
+
+          unless valid = results.detect{|x| results.count(x) > 1 }.blank?
+            @failure_messages << "- `unique_id` block argument must return unique values"
+          end
+          valid
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,3 +54,7 @@ def build_dummy_base_class
   klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
   klass
 end
+
+def basic_random_proc
+  Proc.new { "R#{Array.new(9) { rand(9) }.join}" }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,19 +29,11 @@ RSpec.configure do |config|
 end
 
 
-def build_dummy_class(unique_attr_name, unique_options = {}, class_options = {})
-  # setup class and include delayed_cron
-
-  class_name = "DummyModel"
-
-  ActiveRecord::Base.send(:include, UniqueIdentifier::Glue)
-  Object.send(:remove_const, class_name) rescue nil
-
-  # Set class as a constant
-  klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
+def build_dummy_class(unique_attr_name = nil, unique_options = {}, class_options = {})
+  # setup class and include unique_identifier
+  klass = build_dummy_base_class
 
   klass.class_eval do
-
     unique_id unique_attr_name, unique_options
 
     if class_options.fetch(:validate, false)
@@ -49,5 +41,16 @@ def build_dummy_class(unique_attr_name, unique_options = {}, class_options = {})
     end
   end
 
+  klass
+end
+
+def build_dummy_base_class
+  class_name = "DummyModel"
+
+  ActiveRecord::Base.send(:include, UniqueIdentifier::Glue)
+  Object.send(:remove_const, class_name) rescue nil
+
+  # Set class as a constant
+  klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
   klass
 end

--- a/spec/unique_identifier/matchers/have_unique_id_matcher_spec.rb
+++ b/spec/unique_identifier/matchers/have_unique_id_matcher_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'unique_identifier/matchers'
+
+describe UniqueIdentifier::Shoulda::Matchers::HaveUniqueIdMatcher do
+  extend UniqueIdentifier::Shoulda::Matchers
+  let(:matcher) { self.class.have_unique_id(:number) }
+
+  it "rejects the dummy class if it does not call `unique_id` for the column" do
+    DummyModel = build_dummy_base_class
+    expect(matcher.matches?(DummyModel)).to be_falsy
+  end
+
+  it "rejects the dummy class if the block does not return a unique string" do
+    DummyModel = build_dummy_class(:number, Proc.new { "R1111111" })
+    expect(matcher.matches?(DummyModel)).to be_falsy
+  end
+
+  it 'accepts the dummy class if it does call `unique_id` for the column' do
+    DummyModel = build_dummy_class(:number, basic_random_proc)
+    expect(matcher.matches?(DummyModel)).to be_truthy
+  end
+end

--- a/spec/unique_identifier_spec.rb
+++ b/spec/unique_identifier_spec.rb
@@ -33,10 +33,7 @@ describe UniqueIdentifier do
 
       context "when unique_id attribute +is not+ validated" do
         before do
-          DummyModel = build_dummy_class(
-            :number,
-            Proc.new { "R#{Array.new(9) { rand(9) }.join}" }
-          )
+          DummyModel = build_dummy_class(:number, basic_random_proc)
         end
 
         let(:model) { DummyModel.create }
@@ -48,11 +45,7 @@ describe UniqueIdentifier do
 
       context "when unique_id attribute +is+ validated" do
         before do
-          DummyModel = build_dummy_class(
-            :number,
-            Proc.new { "R#{Array.new(9) { rand(9) }.join}" },
-            validate: true
-          )
+          DummyModel = build_dummy_class(:number, basic_random_proc, validate: true)
         end
 
         let(:model) { DummyModel.create }

--- a/spec/unique_identifier_spec.rb
+++ b/spec/unique_identifier_spec.rb
@@ -3,6 +3,32 @@ require 'spec_helper'
 describe UniqueIdentifier do
   describe ".unique_identifier" do
 
+    context "instance methods" do
+      context "when unique_id is not called on class" do
+        before do
+          DummyModel = build_dummy_base_class
+        end
+
+        let(:model) { DummyModel.create }
+
+        it "does not include instance methods on the class" do
+          expect(model.respond_to?(:generate_unique_id)).to be_falsy
+        end
+      end
+
+      context "when unique_id is called on class" do
+        before do
+          DummyModel = build_dummy_class(:number, basic_random_proc)
+        end
+
+        let(:model) { DummyModel.create }
+
+        it "does not include instance methods on the class" do
+          expect(model.respond_to?(:generate_unique_id)).to be_truthy
+        end
+      end
+    end
+
     context "callbacks" do
 
       context "when unique_id attribute +is not+ validated" do


### PR DESCRIPTION
- small refactor to delay including `InstanceMethods` until `unique_id` is called on the class
- this way we can make a custom matcher to test (in part) the inclusion of the instance methods on the class as partial evidence that the class is using `unique_id`
- [ ] note: currently depends slightly on https://github.com/jGRUBBS/unique_identifier/pull/2/ but those updates can be easily taken out

### custom matcher references
- https://github.com/rspec/rspec-expectations/blob/master/Should.md
- https://medium.com/@igor_marques/writing-custom-matchers-15bd3d866079
- http://rspec.info/documentation/3.7/rspec-expectations/RSpec/Matchers.html
- https://relishapp.com/rspec/rspec-expectations/v/3-7/docs/custom-matchers/define-a-custom-matcher
- https://robots.thoughtbot.com/shoulda-matchers